### PR TITLE
support ie8 in built files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,5 +30,9 @@ var self = module.exports = {
 
 if (isProduction) {
     self.output.filename = "[name].min.js";
-    self.plugins = [new webpack.optimize.UglifyJsPlugin()];
+    self.plugins = [new webpack.optimize.UglifyJsPlugin({
+        compress: { screw_ie8: false },
+        mangle:   { screw_ie8: false },
+        output:   { screw_ie8: false, beautify: false }
+    })];
 }


### PR DESCRIPTION
The built file currently contains `.default` which fails in IE version less than 9. The change I made will make the built file contain `["default"]`, which works in all browsers.