### PR TITLE
Use native Promise instead of setTimeout as it is not vulnerable to throttling

### DIFF
--- a/src/yaku.core.js
+++ b/src/yaku.core.js
@@ -38,7 +38,9 @@
 
     , Symbol = root[$Symbol] || {}
     , nextTick = isBrowser ?
-        function (fn) { setTimeout(fn); } :
+        function (fn) {
+            window.Promise ? new window.Promise(function (resolve) { resolve(); }).then(fn) : setTimeout(fn);
+        } :
         process.nextTick
     , speciesConstructor = function (O, D) {
         var C = O.constructor;


### PR DESCRIPTION
FF and Chrome are throttling setTimeout to 1000ms in inactive tabs:
https://bugzilla.mozilla.org/show_bug.cgi?id=633421
https://bugs.chromium.org/p/chromium/issues/detail?id=66078

I've encountered a problem with flaky test and after a while of debugging it turned out to be a problem with Yaku using setTimeout. Debug log statements happened in exact 1 second time distance, while they were called one after each other. 
The reason for this was special behavior of Chrome on OSX, where setTimeout is clamped for a window that is not on the top.

The solution is to use native Promise if possible as this is closer to node nextTick.

Quick jsfiddle to play with this: https://jsfiddle.net/0npx5v5r/